### PR TITLE
Allow attributesRenderer to compute cell component

### DIFF
--- a/src/DataSheet.js
+++ b/src/DataSheet.js
@@ -329,12 +329,14 @@ export default class DataSheet extends PureComponent {
                   value: valueRenderer(cell, i, j),
                   attributes: attributesRenderer ? attributesRenderer(cell, i, j) : {}
                 }
+                
+                const component = cell.component || props.attributes.component
 
-                if (cell.component) {
+                if (component) {
                   return <ComponentCell
                     {...props}
                     forceComponent={cell.forceComponent || false}
-                    component={cell.component}
+                    component={component}
                   />
                 }
 


### PR DESCRIPTION
This way we can delegate the task of computing the final cell component to the attributesRenderer without having to keep on track of the individual components under the dataset.